### PR TITLE
only support python 3.6+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,6 @@ matrix:
     env: TOXENV=py37
   - python: "3.6"
     env: TOXENV=py36
-  - python: "3.5"
-    env: TOXENV=py35
-  - python: "3.4"
-    env: TOXENV=py34
 
 install:
   - pip install --upgrade tox

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -22,7 +22,7 @@ Installation
   pip install exceptional
 
 ``exceptional`` supports reasonably modern Python versions, which at
-the time of writing means Python 3.4+.
+the time of writing means Python 3.6+.
 
 Usage
 =====

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py34,py35,py36,py37
+envlist = py36,py37
 
 [testenv]
 deps=-rrequirements-test.txt


### PR DESCRIPTION
this makes it possible to use f-strings and type annotations.